### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Generally this is the easiest approach.
 1. Add a list of library names to an arbitrary environment variable (separated by colon), and set the `search_paths_env` member to the name of that environment variable
 
 ## Defining a plugin base class
-The only requirement for a plugin base class is that it have a member `static std::string section` which defines a section name for the plugin and is accessible to the plugin loader class.
+At a minimum, there are no requirements on the definition of a base class that can be used with this plugin loader.
+However, there is one optional requirement for enabling the plugin loader to discover the names of all plugins inheriting a specific base class type.
+Namely, the plugin base class must have a member function `static std::string getSection()` which defines a section name for the plugin and is accessible to the `PluginLoader` and `has_getSection` classes.
 The section name is a unique 8-byte string that associates implementations to the base class.
-The plugin loader method `getAllAvailablePlugins` can identify all symbols in a library with this section name and thereby return all implementations of a particular base class.
+The plugin loader method `getAvailablePlugins` can identify all symbols in a library with this section name and thereby return all implementations of a particular base class.
 It is also generally useful to define a new export macro for the base class that invokes the `EXPORT_CLASS_SECTIONED` macro with the section name directly.
 See the [test plugin base class definition](examples/plugin.h) for an example.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,3 +16,13 @@ target_link_libraries(${PROJECT_NAME}_example PRIVATE ${PROJECT_NAME}_example_pl
 target_compile_definitions(${PROJECT_NAME}_example PRIVATE PLUGIN_DIR="${CMAKE_CURRENT_BINARY_DIR}"
                                                            PLUGINS="${PROJECT_NAME}_example_plugin_impl")
 target_clang_tidy(${PROJECT_NAME}_example ENABLE ${ENABLE_CLANG_TIDY})
+
+# Install the plugin libraries
+install(
+  TARGETS ${PROJECT_NAME}_example_plugin ${PROJECT_NAME}_example_plugin_impl
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+# Install the example executable
+install(TARGETS ${PROJECT_NAME}_example RUNTIME DESTINATION lib/${PROJECT_NAME})

--- a/examples/plugin.cpp
+++ b/examples/plugin.cpp
@@ -23,19 +23,17 @@ namespace boost_plugin_loader
 {
 // Define the section name for loading plugins of base class `Printer`
 // This should match the section name specified in the plugin export macro for this class
-const std::string& Printer::getSection()
+std::string Printer::getSection()
 {
-  static const std::string section = "printer";
-  return section;
+  return "printer";
 }
 INSTANTIATE_PLUGIN_LOADER(Printer)
 
 // Define the section name for loading plugins of base class `Shape`
 // This should match the section name specified in the plugin export macro for this class
-const std::string& Shape::getSection()
+std::string Shape::getSection()
 {
-  static const std::string section = "shape";
-  return section;
+  return "shape";
 }
 INSTANTIATE_PLUGIN_LOADER(Shape)
 }  // namespace boost_plugin_loader

--- a/examples/plugin.h
+++ b/examples/plugin.h
@@ -23,16 +23,23 @@
 
 namespace boost_plugin_loader
 {
+// Forward declare PluginLoader and has_getSection classes
+class PluginLoader;
+
+template <typename T>
+struct has_getSection;
+
 /** @brief Plugin interface implementation for testing */
 class Printer
 {
 public:
   using Ptr = std::shared_ptr<Printer>;
   virtual void operator()() const = 0;
-  static const std::string& getSection();
 
 private:
   friend class PluginLoader;
+  friend struct has_getSection<Printer>;
+  static std::string getSection();
 };
 
 /** @brief Plugin interface implementation for testing */
@@ -41,10 +48,11 @@ class Shape
 public:
   using Ptr = std::shared_ptr<Shape>;
   virtual void operator()() const = 0;
-  static const std::string& getSection();
 
 private:
   friend class PluginLoader;
+  friend struct has_getSection<Shape>;
+  static std::string getSection();
 };
 
 }  // namespace boost_plugin_loader

--- a/include/boost_plugin_loader/macros.h
+++ b/include/boost_plugin_loader/macros.h
@@ -16,7 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef BOOST_PLUGIN_LOADER_MACROS_H
+#define BOOST_PLUGIN_LOADER_MACROS_H
 
 #include <boost/dll/alias.hpp>
 
@@ -24,3 +25,5 @@
 #define EXPORT_CLASS_SECTIONED(DERIVED_CLASS, ALIAS, SECTION)                                                          \
   extern "C" BOOST_SYMBOL_EXPORT DERIVED_CLASS ALIAS;                                                                  \
   BOOST_DLL_SECTION(SECTION, read) BOOST_DLL_SELECTANY DERIVED_CLASS ALIAS;
+
+#endif // BOOST_PLUGIN_LOADER_MACROS_H

--- a/include/boost_plugin_loader/plugin_loader.h
+++ b/include/boost_plugin_loader/plugin_loader.h
@@ -145,6 +145,4 @@ public:
 
 }  // namespace boost_plugin_loader
 
-#include <boost_plugin_loader/plugin_loader.hpp>
-
 #endif  // BOOST_PLUGIN_LOADER_PLUGIN_LOADER_H

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <boost_plugin_loader/utils.h>
-#include <boost_plugin_loader/plugin_loader.h>
+#include <boost_plugin_loader/plugin_loader.hpp>
 #include "test_plugin_base.h"
 
 TEST(BoostPluginLoaderUnit, Utils)  // NOLINT

--- a/test/test_plugin_base.h
+++ b/test/test_plugin_base.h
@@ -28,10 +28,9 @@ class TestPluginBase
 public:
   virtual ~TestPluginBase() = default;
   virtual double multiply(double x, double y) = 0;
-  static const std::string& getSection()
+  static std::string getSection()
   {
-    static const std::string section = "TestBase";
-    return section;
+    return "TestBase";
   }
 
 protected:


### PR DESCRIPTION
Various updates per commit messages
- ~~Replaced header guards with `#pragma once` for simplicity and to ensure conflict avoidance~~
- Updated README to reflect `getSection` base class requirement
- Updated example
  - Hide `getSection` from the public API of the example plugins
  - Return strings rather than references
  - Install the example so it can be run
- Removed include of `plugin_loader.hpp` in `plugin_loader.h` to reduce build times and allow for correct explicit template instantiation