### PR TITLE
Update Ubuntu Focal CI job

### DIFF
--- a/.github/workflows/ubuntu_focal.yml
+++ b/.github/workflows/ubuntu_focal.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   ci:
     name: Ubuntu-Focal
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
CI for the Ubuntu Focal job is running on `ubuntu-latest` which is now Ubuntu 22.04. This PR changes the job to actually run on 20.04