### PR TITLE
Fix missing algorithm.h header in plugin_loader.hpp

### DIFF
--- a/.github/workflows/windows_2022.yml
+++ b/.github/workflows/windows_2022.yml
@@ -16,6 +16,7 @@ on:
 env:
   VCPKG_PKGS: >-
     boost-dll boost-filesystem boost-algorithm
+    boost-smart-ptr
 
 jobs:
   windows_ci:

--- a/.github/workflows/windows_2022.yml
+++ b/.github/workflows/windows_2022.yml
@@ -1,4 +1,4 @@
-name: Windows-2019
+name: Windows-2022
 
 on:
   push:
@@ -19,8 +19,8 @@ env:
 
 jobs:
   windows_ci:
-    name: Windows-2019
-    runs-on: windows-2019
+    name: Windows-2022
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/windows_2022.yml
+++ b/.github/workflows/windows_2022.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   VCPKG_PKGS: >-
-    boost-dll boost-filesystem
+    boost-dll boost-filesystem boost-algorithm
 
 jobs:
   windows_ci:

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -27,7 +27,6 @@
 #include <boost/core/demangle.hpp>
 #include <boost/dll/import.hpp>
 #include <boost/version.hpp>
-#include <boost/shared_ptr.hpp>
 
 // Boost Plugin Loader
 #include <boost_plugin_loader/plugin_loader.h>

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -27,6 +27,7 @@
 #include <boost/core/demangle.hpp>
 #include <boost/dll/import.hpp>
 #include <boost/version.hpp>
+#include <boost/shared_ptr.hpp>
 
 // Boost Plugin Loader
 #include <boost_plugin_loader/plugin_loader.h>

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -21,6 +21,7 @@
 
 // STD
 #include <sstream>
+#include <algorithm>
 
 // Boost
 #include <boost/core/demangle.hpp>

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -53,11 +53,11 @@ static std::shared_ptr<ClassBase> createSharedInstance(const boost::dll::shared_
                                 "' in library: " + boost::dll::shared_library::decorate(lib.location()).string());
 
 #if BOOST_VERSION >= 107600
-  boost::shared_ptr<ClassBase> plugin = boost::dll::import_symbol<ClassBase>(lib, symbol_name);
+  return boost::dll::import_symbol<ClassBase>(lib, symbol_name);
 #else
-  boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
+boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
+return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
 #endif
-  return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
 }
 
 /**


### PR DESCRIPTION
This PR fixes several Windows build issues:

* The algorithm.h header is not included in plugin_loader.hpp leading to a `std::any_of` identifier not found error. This PR adds the missing include.
* Fix return of `import_symbol` to use `std::shared_ptr` on newer boost versions