### PR TITLE
Fixed shared_ptr type selection in createSharedInstance

### DIFF
--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -55,11 +55,11 @@ static std::shared_ptr<ClassBase> createSharedInstance(const boost::dll::shared_
   return boost::dll::import_symbol<ClassBase>(lib, symbol_name);
 #else
 #if BOOST_VERSION >= 107600
-boost::shared_ptr<ClassBase> plugin = boost::dll::import_symbol <ClassBase>(lib, symbol_name);
+  boost::shared_ptr<ClassBase> plugin = boost::dll::import_symbol<ClassBase>(lib, symbol_name);
 #else
-boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
+  boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
 #endif
-return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
+  return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
 #endif
 }
 

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -51,10 +51,14 @@ static std::shared_ptr<ClassBase> createSharedInstance(const boost::dll::shared_
     throw PluginLoaderException("Failed to find symbol '" + symbol_name +
                                 "' in library: " + boost::dll::shared_library::decorate(lib.location()).string());
 
-#if BOOST_VERSION >= 107600
+#if BOOST_VERSION >= 108800
   return boost::dll::import_symbol<ClassBase>(lib, symbol_name);
 #else
+#if BOOST_VERSION >= 107600
+boost::shared_ptr<ClassBase> plugin = boost::dll::import_symbol <ClassBase>(lib, symbol_name);
+#else
 boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
+#endif
 return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
 #endif
 }


### PR DESCRIPTION
The return type switch to `std::shared_ptr` to `boost::shared_ptr` happened in boost 1.88.0. This adds a few more condition checks to correct the type selection.