### PR TITLE
Ensure symbol is associated with defined section

### DIFF
--- a/include/boost_plugin_loader/plugin_loader.h
+++ b/include/boost_plugin_loader/plugin_loader.h
@@ -30,6 +30,11 @@
   template std::vector<std::string> boost_plugin_loader::PluginLoader::getAvailablePlugins<PluginBase>() const;        \
   template std::shared_ptr<PluginBase> boost_plugin_loader::PluginLoader::createInstance(const std::string&) const;
 
+namespace boost::dll
+{
+class shared_library;
+}
+
 namespace boost_plugin_loader
 {
 /** @brief Used to test for getSection method for getAvailablePlugins */
@@ -156,6 +161,21 @@ protected:
   typename std::enable_if_t<has_getSection<PluginBase>::value, void>
   reportError(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
               const std::set<std::string>& search_paths, const std::set<std::string>& search_libraries) const;
+
+  /**
+   * @brief Checks if the library has the input symbol name, given that the plugin class does not define a section name
+   */
+  template <class ClassBase>
+  typename std::enable_if<!has_getSection<ClassBase>::value, bool>::type
+  hasSymbol(const boost::dll::shared_library& lib, const std::string& symbol_name) const;
+
+  /**
+   * @brief Checks that the library has the input symbol name and that the symbol is associated with the section defined
+   * in the plugin class.
+   */
+  template <class ClassBase>
+  typename std::enable_if<has_getSection<ClassBase>::value, bool>::type hasSymbol(const boost::dll::shared_library& lib,
+                                                                                  const std::string& symbol_name) const;
 };
 
 }  // namespace boost_plugin_loader

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,21 @@
 find_gtest()
 
+add_library(${PROJECT_NAME}_test_plugin INTERFACE test_plugin.h)
+target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE
+  SECTION_MULTIPLY="mult"
+  __SYMBOL_NAME__=plugin)
+
 add_library(${PROJECT_NAME}_test_plugin_multiply test_plugin_multiply.cpp)
-target_link_libraries(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${PROJECT_NAME} Boost::boost)
+target_link_libraries(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin Boost::boost)
 target_compile_definitions(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${COMPILE_DEFINITIONS})
 target_clang_tidy(${PROJECT_NAME}_test_plugin_multiply ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_plugin_multiply PUBLIC VERSION 17)
 
 add_executable(${PROJECT_NAME}_plugin_loader_unit plugin_loader_unit.cpp)
-target_link_libraries(${PROJECT_NAME}_plugin_loader_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_plugin_loader_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin)
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE ${COMPILE_DEFINITIONS})
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE PLUGIN_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-                                                                      PLUGINS="${PROJECT_NAME}_test_plugin_multiply")
+                                                                      PLUGINS_MULTIPLY="${PROJECT_NAME}_test_plugin_multiply")
 target_clang_tidy(${PROJECT_NAME}_plugin_loader_unit ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_plugin_loader_unit PUBLIC VERSION 17)
 target_code_coverage(
@@ -28,6 +33,7 @@ target_link_libraries(
   PRIVATE GTest::GTest
           GTest::Main
           ${PROJECT_NAME}
+          ${PROJECT_NAME}_test_plugin
           ${PROJECT_NAME}_test_plugin_multiply)
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_anchor_unit PRIVATE ${COMPILE_DEFINITIONS})
 target_clang_tidy(${PROJECT_NAME}_plugin_loader_anchor_unit ENABLE ${ENABLE_CLANG_TIDY})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ find_gtest()
 add_library(${PROJECT_NAME}_test_plugin INTERFACE test_plugin.h)
 target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE
   SECTION_MULTIPLY="mult"
+  SECTION_ADD="add"
   __SYMBOL_NAME__=plugin)
 
 add_library(${PROJECT_NAME}_test_plugin_multiply test_plugin_multiply.cpp)
@@ -11,11 +12,18 @@ target_compile_definitions(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${COMPILE
 target_clang_tidy(${PROJECT_NAME}_test_plugin_multiply ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_plugin_multiply PUBLIC VERSION 17)
 
+add_library(${PROJECT_NAME}_test_plugin_add test_plugin_add.cpp)
+target_link_libraries(${PROJECT_NAME}_test_plugin_add PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin Boost::boost)
+target_compile_definitions(${PROJECT_NAME}_test_plugin_add PUBLIC ${COMPILE_DEFINITIONS})
+target_clang_tidy(${PROJECT_NAME}_test_plugin_add ENABLE ${ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_test_plugin_add PUBLIC VERSION 17)
+
 add_executable(${PROJECT_NAME}_plugin_loader_unit plugin_loader_unit.cpp)
 target_link_libraries(${PROJECT_NAME}_plugin_loader_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin)
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE ${COMPILE_DEFINITIONS})
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE PLUGIN_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-                                                                      PLUGINS_MULTIPLY="${PROJECT_NAME}_test_plugin_multiply")
+                                                                      PLUGINS_MULTIPLY="${PROJECT_NAME}_test_plugin_multiply"
+                                                                      PLUGINS_ADD="${PROJECT_NAME}_test_plugin_add")
 target_clang_tidy(${PROJECT_NAME}_plugin_loader_unit ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_plugin_loader_unit PUBLIC VERSION 17)
 target_code_coverage(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 find_gtest()
 
-add_library(${PROJECT_NAME}_test_plugin INTERFACE test_plugin.h)
-target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE SECTION_MULTIPLY="mult" SECTION_ADD="add"
-                                                                 __SYMBOL_NAME__=plugin)
+add_library(${PROJECT_NAME}_test_plugin INTERFACE)
+target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE SECTION_MULTIPLY=mult SECTION_ADD=add
+                                                                 SYMBOL_NAME=plugin)
 
 add_library(${PROJECT_NAME}_test_plugin_multiply test_plugin_multiply.cpp)
 target_link_libraries(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,12 @@
 find_gtest()
 
 add_library(${PROJECT_NAME}_test_plugin INTERFACE test_plugin.h)
-target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE
-  SECTION_MULTIPLY="mult"
-  SECTION_ADD="add"
-  __SYMBOL_NAME__=plugin)
+target_compile_definitions(${PROJECT_NAME}_test_plugin INTERFACE SECTION_MULTIPLY="mult" SECTION_ADD="add"
+                                                                 __SYMBOL_NAME__=plugin)
 
 add_library(${PROJECT_NAME}_test_plugin_multiply test_plugin_multiply.cpp)
-target_link_libraries(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin Boost::boost)
+target_link_libraries(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin
+                                                                  Boost::boost)
 target_compile_definitions(${PROJECT_NAME}_test_plugin_multiply PUBLIC ${COMPILE_DEFINITIONS})
 target_clang_tidy(${PROJECT_NAME}_test_plugin_multiply ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_plugin_multiply PUBLIC VERSION 17)
@@ -19,11 +18,17 @@ target_clang_tidy(${PROJECT_NAME}_test_plugin_add ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_plugin_add PUBLIC VERSION 17)
 
 add_executable(${PROJECT_NAME}_plugin_loader_unit plugin_loader_unit.cpp)
-target_link_libraries(${PROJECT_NAME}_plugin_loader_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME} ${PROJECT_NAME}_test_plugin)
+target_link_libraries(
+  ${PROJECT_NAME}_plugin_loader_unit
+  PRIVATE GTest::GTest
+          GTest::Main
+          ${PROJECT_NAME}
+          ${PROJECT_NAME}_test_plugin)
 target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE ${COMPILE_DEFINITIONS})
-target_compile_definitions(${PROJECT_NAME}_plugin_loader_unit PRIVATE PLUGIN_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-                                                                      PLUGINS_MULTIPLY="${PROJECT_NAME}_test_plugin_multiply"
-                                                                      PLUGINS_ADD="${PROJECT_NAME}_test_plugin_add")
+target_compile_definitions(
+  ${PROJECT_NAME}_plugin_loader_unit
+  PRIVATE PLUGIN_DIR="${CMAKE_CURRENT_BINARY_DIR}" PLUGINS_MULTIPLY="${PROJECT_NAME}_test_plugin_multiply"
+          PLUGINS_ADD="${PROJECT_NAME}_test_plugin_add")
 target_clang_tidy(${PROJECT_NAME}_plugin_loader_unit ENABLE ${ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_plugin_loader_unit PUBLIC VERSION 17)
 target_code_coverage(

--- a/test/plugin_loader_anchor_unit.cpp
+++ b/test/plugin_loader_anchor_unit.cpp
@@ -50,7 +50,7 @@ TEST(BoostPluginLoaderAnchorUnit, LoadTestPlugin)  // NOLINT
 
   std::vector<std::string> sections = plugin_loader.getAvailableSections();
   EXPECT_EQ(sections.size(), 1);
-  EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
+  EXPECT_EQ(sections.at(0), TestPluginMultiply::getSection());
 
   sections = plugin_loader.getAvailableSections(true);
   EXPECT_TRUE(sections.size() > 1);
@@ -59,7 +59,7 @@ TEST(BoostPluginLoaderAnchorUnit, LoadTestPlugin)  // NOLINT
   EXPECT_EQ(symbols.size(), 1);
   EXPECT_EQ(symbols.at(0), getSymbolName());
 
-  symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
+  symbols = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
   EXPECT_EQ(symbols.size(), 1);
   EXPECT_EQ(symbols.at(0), getSymbolName());
 }

--- a/test/plugin_loader_anchor_unit.cpp
+++ b/test/plugin_loader_anchor_unit.cpp
@@ -29,38 +29,39 @@
 #include <boost_plugin_loader/plugin_loader.h>
 #include <boost_plugin_loader/plugin_loader.hpp>  // NOLINT(misc-include-cleaner)
 #include <boost_plugin_loader/utils.h>
-#include "test_plugin_base.h"
+#include "test_plugin.h"
 #include "test_plugin_multiply.h"
 
 TEST(BoostPluginLoaderAnchorUnit, LoadTestPlugin)  // NOLINT
 {
   using boost_plugin_loader::PluginLoader;
-  using boost_plugin_loader::TestPluginBase;
+  using boost_plugin_loader::TestPluginMultiply;
 
-  boost_plugin_loader::addSymbolLibraryToSearchLibrariesEnv(boost_plugin_loader::TestPluginMultiplyAnchor(), "UNITTESTE"
-                                                                                                             "NV");
+  boost_plugin_loader::addSymbolLibraryToSearchLibrariesEnv(boost_plugin_loader::TestPluginMultiplyImplAnchor(), "UNITT"
+                                                                                                                 "ESTEN"
+                                                                                                                 "V");
   PluginLoader plugin_loader;
   plugin_loader.search_libraries_env = "UNITTESTENV";
 
-  EXPECT_TRUE(plugin_loader.isPluginAvailable("plugin"));
-  auto plugin = plugin_loader.createInstance<TestPluginBase>("plugin");
+  EXPECT_TRUE(plugin_loader.isPluginAvailable(getSymbolName()));
+  auto plugin = plugin_loader.createInstance<TestPluginMultiply>(getSymbolName());
   EXPECT_TRUE(plugin != nullptr);
   EXPECT_NEAR(plugin->multiply(5, 5), 25, 1e-8);
 
   std::vector<std::string> sections = plugin_loader.getAvailableSections();
   EXPECT_EQ(sections.size(), 1);
-  EXPECT_EQ(sections.at(0), "TestBase");
+  EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
 
   sections = plugin_loader.getAvailableSections(true);
   EXPECT_TRUE(sections.size() > 1);
 
-  std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginBase>();
+  std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginMultiply>();
   EXPECT_EQ(symbols.size(), 1);
-  EXPECT_EQ(symbols.at(0), "plugin");
+  EXPECT_EQ(symbols.at(0), getSymbolName());
 
-  symbols = plugin_loader.getAvailablePlugins("TestBase");
+  symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
   EXPECT_EQ(symbols.size(), 1);
-  EXPECT_EQ(symbols.at(0), "plugin");
+  EXPECT_EQ(symbols.at(0), getSymbolName());
 }
 
 int main(int argc, char** argv)

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -36,14 +36,13 @@
 #include <boost_plugin_loader/utils.h>
 #include <boost_plugin_loader/plugin_loader.h>
 #include <boost_plugin_loader/plugin_loader.hpp>
-#include "test_plugin_base.h"
+#include "test_plugin.h"
 
 TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
 {
   using namespace boost_plugin_loader;
-  const std::string lib_name = std::string(PLUGINS);
+  const std::string lib_name = std::string(PLUGINS_MULTIPLY);
   const std::string lib_dir = std::string(PLUGIN_DIR);
-  const std::string symbol_name = "plugin";
 
   {
 #ifndef _WIN32
@@ -131,26 +130,26 @@ TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
   {
     std::vector<std::string> sections = getAllAvailableSections(lib);
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), "TestBase");
+    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
 
     sections = getAllAvailableSections(lib, true);
     EXPECT_TRUE(sections.size() > 1);
   }
 
   {
-    std::vector<std::string> symbols = getAllAvailableSymbols(lib, "TestBase");
+    std::vector<std::string> symbols = getAllAvailableSymbols(lib, SECTION_MULTIPLY);
     EXPECT_EQ(symbols.size(), 1);
-    EXPECT_EQ(symbols.at(0), symbol_name);
+    EXPECT_EQ(symbols.at(0), getSymbolName());
   }
 
   {
-    EXPECT_TRUE(lib.has(symbol_name));
+    EXPECT_TRUE(lib.has(getSymbolName()));
   }
 
 // For some reason on Ubuntu 18.04 it does not search the current directory when only the library name is provided
 #if BOOST_VERSION > 106800
   {
-    EXPECT_TRUE(lib.has(symbol_name));
+    EXPECT_TRUE(lib.has(getSymbolName()));
   }
 #endif
 
@@ -160,66 +159,66 @@ TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
 
   // Load the plugin
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-  EXPECT_NO_THROW(createSharedInstance<TestPluginBase>(lib, symbol_name));
+  EXPECT_NO_THROW(createSharedInstance<TestPluginMultiply>(lib, getSymbolName()));
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-  EXPECT_ANY_THROW(createSharedInstance<TestPluginBase>(lib, "does_not_exist"));
+  EXPECT_ANY_THROW(createSharedInstance<TestPluginMultiply>(lib, "does_not_exist"));
 }
 
 TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
 {
   using boost_plugin_loader::PluginLoader;
-  using boost_plugin_loader::TestPluginBase;
+  using boost_plugin_loader::TestPluginMultiply;
 
   {
     PluginLoader plugin_loader;
     plugin_loader.search_paths.insert(std::string(PLUGIN_DIR));
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
-    EXPECT_TRUE(plugin_loader.isPluginAvailable("plugin"));
-    auto plugin = plugin_loader.createInstance<TestPluginBase>("plugin");
+    EXPECT_TRUE(plugin_loader.isPluginAvailable(getSymbolName()));
+    auto plugin = plugin_loader.createInstance<TestPluginMultiply>(getSymbolName());
     EXPECT_TRUE(plugin != nullptr);
     EXPECT_NEAR(plugin->multiply(5, 5), 25, 1e-8);
 
     std::vector<std::string> sections = plugin_loader.getAvailableSections();
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), "TestBase");
+    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
 
     sections = plugin_loader.getAvailableSections(true);
     EXPECT_TRUE(sections.size() > 1);
 
-    std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginBase>();
+    std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginMultiply>();
     EXPECT_EQ(symbols.size(), 1);
-    EXPECT_EQ(symbols.at(0), "plugin");
+    EXPECT_EQ(symbols.at(0), getSymbolName());
 
-    symbols = plugin_loader.getAvailablePlugins("TestBase");
+    symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
     EXPECT_EQ(symbols.size(), 1);
-    EXPECT_EQ(symbols.at(0), "plugin");
+    EXPECT_EQ(symbols.at(0), getSymbolName());
   }
 
   {  // Use full path
     PluginLoader plugin_loader;
-    const std::string full_path = boost_plugin_loader::decorate(std::string(PLUGINS), std::string(PLUGIN_DIR));
+    const std::string full_path = boost_plugin_loader::decorate(std::string(PLUGINS_MULTIPLY), std::string(PLUGIN_DIR));
     plugin_loader.search_libraries.insert(full_path);
 
-    EXPECT_TRUE(plugin_loader.isPluginAvailable("plugin"));
-    auto plugin = plugin_loader.createInstance<TestPluginBase>("plugin");
+    EXPECT_TRUE(plugin_loader.isPluginAvailable(getSymbolName()));
+    auto plugin = plugin_loader.createInstance<TestPluginMultiply>(getSymbolName());
     EXPECT_TRUE(plugin != nullptr);
     EXPECT_NEAR(plugin->multiply(5, 5), 25, 1e-8);
 
     std::vector<std::string> sections = plugin_loader.getAvailableSections();
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), "TestBase");
+    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
 
     sections = plugin_loader.getAvailableSections(true);
     EXPECT_TRUE(sections.size() > 1);
 
-    std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginBase>();
+    std::vector<std::string> symbols = plugin_loader.getAvailablePlugins<TestPluginMultiply>();
     EXPECT_EQ(symbols.size(), 1);
-    EXPECT_EQ(symbols.at(0), "plugin");
+    EXPECT_EQ(symbols.at(0), getSymbolName());
 
-    symbols = plugin_loader.getAvailablePlugins("TestBase");
+    symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
     EXPECT_EQ(symbols.size(), 1);
-    EXPECT_EQ(symbols.at(0), "plugin");
+    EXPECT_EQ(symbols.at(0), getSymbolName());
   }
 
 // For some reason on Ubuntu 18.04 it does not search the current directory when only the library name is provided
@@ -228,12 +227,12 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     PluginLoader plugin_loader;
     EXPECT_EQ(plugin_loader.count(), 0);
     EXPECT_TRUE(plugin_loader.empty());
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
     EXPECT_EQ(plugin_loader.count(), 1);
     EXPECT_FALSE(plugin_loader.empty());
 
-    EXPECT_TRUE(plugin_loader.isPluginAvailable("plugin"));
-    auto plugin = plugin_loader.createInstance<TestPluginBase>("plugin");
+    EXPECT_TRUE(plugin_loader.isPluginAvailable(getSymbolName()));
+    auto plugin = plugin_loader.createInstance<TestPluginMultiply>(getSymbolName());
     EXPECT_TRUE(plugin != nullptr);
     EXPECT_NEAR(plugin->multiply(5, 5), 25, 1e-8);
   }
@@ -244,25 +243,25 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
     plugin_loader.search_paths.insert("does_not_exist");
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
-    EXPECT_FALSE(plugin_loader.isPluginAvailable("plugin"));
+    EXPECT_FALSE(plugin_loader.isPluginAvailable(getSymbolName()));
     // Behavior change: used to return nullptr but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
   }
 #endif
 
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
     {
       EXPECT_FALSE(plugin_loader.isPluginAvailable("does_not_exist"));
       // Behavior change: used to return nullptr but now throws exception
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("does_not_exist"));
+      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>("does_not_exist"));
     }
 
     plugin_loader.search_system_folders = true;
@@ -271,7 +270,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
       EXPECT_FALSE(plugin_loader.isPluginAvailable("does_not_exist"));
       // Behavior change: used to return nullptr but now throws exception
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("does_not_exist"));
+      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>("does_not_exist"));
     }
   }
 
@@ -281,38 +280,38 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     plugin_loader.search_libraries.insert("does_not_exist");
 
     {
-      EXPECT_FALSE(plugin_loader.isPluginAvailable("plugin"));
+      EXPECT_FALSE(plugin_loader.isPluginAvailable(getSymbolName()));
       // Behavior change: used to return nullptr but now throws exception
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("plugin"));
+      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
     }
 
     plugin_loader.search_system_folders = true;
 
     {
-      EXPECT_FALSE(plugin_loader.isPluginAvailable("plugin"));
+      EXPECT_FALSE(plugin_loader.isPluginAvailable(getSymbolName()));
       // Behavior change: used to return nullptr but now throws exception
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("plugin"));
+      EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
     }
   }
 
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins("TestBase");
+    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
     EXPECT_EQ(plugins.size(), 0);
   }
 
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = true;
-    plugin_loader.search_libraries.insert(std::string(PLUGINS));
+    plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
-    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins("TestBase");
+    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
     EXPECT_EQ(plugins.size(), 1);
   }
 
@@ -320,16 +319,16 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     const PluginLoader plugin_loader;
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins("TestBase"));
+    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(SECTION_MULTIPLY));
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailableSections("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.getAvailableSections());
     // Behavior change: used to return nullptr but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.isPluginAvailable("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.isPluginAvailable(getSymbolName()));
     // Behavior change: used to return nullptr but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
   }
 
   {
@@ -337,16 +336,16 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     plugin_loader.search_system_folders = false;
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins("TestBase"));
+    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(SECTION_MULTIPLY));
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailableSections("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.getAvailableSections());
     // Behavior change: used to return nullptr but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.isPluginAvailable("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.isPluginAvailable(getSymbolName()));
     // Behavior change: used to return nullptr but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginBase>("plugin"));
+    EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
   }
 }
 

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -130,14 +130,14 @@ TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
   {
     std::vector<std::string> sections = getAllAvailableSections(lib);
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
+    EXPECT_EQ(sections.at(0), TestPluginMultiply::getSection());
 
     sections = getAllAvailableSections(lib, true);
     EXPECT_TRUE(sections.size() > 1);
   }
 
   {
-    std::vector<std::string> symbols = getAllAvailableSymbols(lib, SECTION_MULTIPLY);
+    std::vector<std::string> symbols = getAllAvailableSymbols(lib, TestPluginMultiply::getSection());
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), getSymbolName());
   }
@@ -181,7 +181,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
 
     std::vector<std::string> sections = plugin_loader.getAvailableSections();
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
+    EXPECT_EQ(sections.at(0), TestPluginMultiply::getSection());
 
     sections = plugin_loader.getAvailableSections(true);
     EXPECT_TRUE(sections.size() > 1);
@@ -190,7 +190,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), getSymbolName());
 
-    symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
+    symbols = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), getSymbolName());
   }
@@ -207,7 +207,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
 
     std::vector<std::string> sections = plugin_loader.getAvailableSections();
     EXPECT_EQ(sections.size(), 1);
-    EXPECT_EQ(sections.at(0), SECTION_MULTIPLY);
+    EXPECT_EQ(sections.at(0), TestPluginMultiply::getSection());
 
     sections = plugin_loader.getAvailableSections(true);
     EXPECT_TRUE(sections.size() > 1);
@@ -216,7 +216,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), getSymbolName());
 
-    symbols = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
+    symbols = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), getSymbolName());
   }
@@ -302,7 +302,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
+    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
     EXPECT_EQ(plugins.size(), 0);
   }
 
@@ -311,7 +311,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     plugin_loader.search_system_folders = true;
     plugin_loader.search_libraries.insert(std::string(PLUGINS_MULTIPLY));
 
-    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(SECTION_MULTIPLY);
+    const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
     EXPECT_EQ(plugins.size(), 1);
   }
 
@@ -319,7 +319,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     const PluginLoader plugin_loader;
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(SECTION_MULTIPLY));
+    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection()));
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_ANY_THROW(plugin_loader.getAvailableSections());
@@ -336,7 +336,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     plugin_loader.search_system_folders = false;
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
-    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(SECTION_MULTIPLY));
+    EXPECT_ANY_THROW(plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection()));
     // Behavior change: used to return empty vector but now throws exception
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_ANY_THROW(plugin_loader.getAvailableSections());

--- a/test/test_plugin.h
+++ b/test/test_plugin.h
@@ -19,6 +19,10 @@
 #ifndef BOOST_PLUGIN_LOADER_TEST_PLUGIN_H
 #define BOOST_PLUGIN_LOADER_TEST_PLUGIN_H
 
+// Macros for converting a non-string target compile definition into a string
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
+
 #include <string>
 
 namespace boost_plugin_loader
@@ -33,7 +37,7 @@ public:
   virtual double multiply(double x, double y) = 0;
   static std::string getSection()
   {
-    return SECTION_MULTIPLY;
+    return STRINGIFY(SECTION_MULTIPLY);
   }
 
 protected:
@@ -50,7 +54,7 @@ public:
   virtual double add(double x, double y) = 0;
   static std::string getSection()
   {
-    return SECTION_ADD;
+    return STRINGIFY(SECTION_ADD);
   }
 
 protected:
@@ -59,16 +63,12 @@ protected:
 
 }  // namespace boost_plugin_loader
 
-// Macros for converting a non-string target compile definition into a string
-#define STRINGIFY_HELPER(x) #x
-#define STRINGIFY(x) STRINGIFY_HELPER(x)
-
 /**
  * @brief Function for getting the symbol name from the target compile definition __SYMBOL_NAME__
  */
 static inline std::string getSymbolName()
 {
-  return STRINGIFY(__SYMBOL_NAME__);
+  return STRINGIFY(SYMBOL_NAME);
 }
 
 // Create macros to export both plugins with a given alias and with section names defined as target compile definitions

--- a/test/test_plugin.h
+++ b/test/test_plugin.h
@@ -16,21 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef BOOST_PLUGIN_LOADER_TEST_PLUGIN_BASE_H
-#define BOOST_PLUGIN_LOADER_TEST_PLUGIN_BASE_H
+#ifndef BOOST_PLUGIN_LOADER_TEST_PLUGIN_H
+#define BOOST_PLUGIN_LOADER_TEST_PLUGIN_H
 
 #include <string>
 
 namespace boost_plugin_loader
 {
-class TestPluginBase
+/**
+ * @brief Dummy plugin interface for performing multiplication
+ */
+class TestPluginMultiply
 {
 public:
-  virtual ~TestPluginBase() = default;
+  virtual ~TestPluginMultiply() = default;
   virtual double multiply(double x, double y) = 0;
   static std::string getSection()
   {
-    return "TestBase";
+    return SECTION_MULTIPLY;
   }
 
 protected:
@@ -39,7 +42,17 @@ protected:
 
 }  // namespace boost_plugin_loader
 
-#include <boost_plugin_loader/macros.h>
-#define EXPORT_TEST_PLUGIN(DERIVED_CLASS, ALIAS) EXPORT_CLASS_SECTIONED(DERIVED_CLASS, ALIAS, TestBase)
+// Macros for converting a non-string target compile definition into a string
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#endif  // BOOST_PLUGIN_LOADER_TEST_PLUGIN_BASE_H
+/**
+ * @brief Function for getting the symbol name from the target compile definition __SYMBOL_NAME__
+ */
+static inline std::string getSymbolName() { return STRINGIFY(__SYMBOL_NAME__); }
+
+// Create macros to export both plugins with a given alias and with section names defined as target compile definitions
+#include <boost_plugin_loader/macros.h>
+#define EXPORT_TEST_PLUGIN_MULTIPLY(DERIVED_CLASS, ALIAS) EXPORT_CLASS_SECTIONED(DERIVED_CLASS, ALIAS, SECTION_MULTIPLY)
+
+#endif  // BOOST_PLUGIN_LOADER_TEST_PLUGIN_H

--- a/test/test_plugin.h
+++ b/test/test_plugin.h
@@ -40,6 +40,23 @@ protected:
   friend class PluginLoader;
 };
 
+/**
+ * @brief Dummy plugin interface for performing addition
+ */
+class TestPluginAdd
+{
+public:
+  virtual ~TestPluginAdd() = default;
+  virtual double add(double x, double y) = 0;
+  static std::string getSection()
+  {
+    return SECTION_ADD;
+  }
+
+protected:
+  friend class PluginLoader;
+};
+
 }  // namespace boost_plugin_loader
 
 // Macros for converting a non-string target compile definition into a string
@@ -49,10 +66,14 @@ protected:
 /**
  * @brief Function for getting the symbol name from the target compile definition __SYMBOL_NAME__
  */
-static inline std::string getSymbolName() { return STRINGIFY(__SYMBOL_NAME__); }
+static inline std::string getSymbolName()
+{
+  return STRINGIFY(__SYMBOL_NAME__);
+}
 
 // Create macros to export both plugins with a given alias and with section names defined as target compile definitions
 #include <boost_plugin_loader/macros.h>
 #define EXPORT_TEST_PLUGIN_MULTIPLY(DERIVED_CLASS, ALIAS) EXPORT_CLASS_SECTIONED(DERIVED_CLASS, ALIAS, SECTION_MULTIPLY)
+#define EXPORT_TEST_PLUGIN_ADD(DERIVED_CLASS, ALIAS) EXPORT_CLASS_SECTIONED(DERIVED_CLASS, ALIAS, SECTION_ADD)
 
 #endif  // BOOST_PLUGIN_LOADER_TEST_PLUGIN_H

--- a/test/test_plugin_add.cpp
+++ b/test/test_plugin_add.cpp
@@ -46,6 +46,6 @@ PLUGIN_ANCHOR_IMPL(TestPluginAddImplAnchor)
 
 }  // namespace boost_plugin_loader
 
-// Export the plugin with an alias defined by the target compile definition __SYMBOL_NAME__
+// Export the plugin with an alias defined by the target compile definition SYMBOL_NAME
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-EXPORT_TEST_PLUGIN_ADD(boost_plugin_loader::TestPluginAddImpl, __SYMBOL_NAME__)
+EXPORT_TEST_PLUGIN_ADD(boost_plugin_loader::TestPluginAddImpl, SYMBOL_NAME)

--- a/test/test_plugin_add.cpp
+++ b/test/test_plugin_add.cpp
@@ -1,0 +1,51 @@
+/**
+ *
+ * @copyright Copyright (c) 2021, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_plugin.h"
+
+// Boost Plugin Loader
+#include <boost_plugin_loader/macros.h>
+
+namespace boost_plugin_loader
+{
+class TestPluginAddImpl : public TestPluginAdd
+{
+public:
+  TestPluginAddImpl() = default;
+  ~TestPluginAddImpl() override = default;
+  TestPluginAddImpl(const TestPluginAddImpl&) = default;
+  TestPluginAddImpl& operator=(const TestPluginAddImpl&) = default;
+  TestPluginAddImpl(TestPluginAddImpl&&) = default;
+
+  TestPluginAddImpl& operator=(TestPluginAddImpl&&) = default;
+
+  double add(double x, double y) override
+  {
+    return x + y;
+  }
+};
+
+PLUGIN_ANCHOR_DECL(TestPluginAddImplAnchor)
+PLUGIN_ANCHOR_IMPL(TestPluginAddImplAnchor)
+
+}  // namespace boost_plugin_loader
+
+// Export the plugin with an alias defined by the target compile definition __SYMBOL_NAME__
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+EXPORT_TEST_PLUGIN_ADD(boost_plugin_loader::TestPluginAddImpl, __SYMBOL_NAME__)

--- a/test/test_plugin_multiply.cpp
+++ b/test/test_plugin_multiply.cpp
@@ -33,6 +33,6 @@ PLUGIN_ANCHOR_IMPL(TestPluginMultiplyImplAnchor)
 
 }  // namespace boost_plugin_loader
 
-// Export the plugin with an alias defined by the target compile definition __SYMBOL_NAME__
+// Export the plugin with an alias defined by the target compile definition SYMBOL_NAME
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-EXPORT_TEST_PLUGIN_MULTIPLY(boost_plugin_loader::TestPluginMultiplyImpl, __SYMBOL_NAME__)
+EXPORT_TEST_PLUGIN_MULTIPLY(boost_plugin_loader::TestPluginMultiplyImpl, SYMBOL_NAME)

--- a/test/test_plugin_multiply.cpp
+++ b/test/test_plugin_multiply.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-#include "test_plugin_base.h"
 #include "test_plugin_multiply.h"
 
 // Boost Plugin Loader
@@ -25,14 +24,15 @@
 
 namespace boost_plugin_loader
 {
-double TestPluginMultiply::multiply(double x, double y)
+double TestPluginMultiplyImpl::multiply(double x, double y)
 {
   return x * y;
 }
 
-PLUGIN_ANCHOR_IMPL(TestPluginMultiplyAnchor)
+PLUGIN_ANCHOR_IMPL(TestPluginMultiplyImplAnchor)
 
 }  // namespace boost_plugin_loader
 
+// Export the plugin with an alias defined by the target compile definition __SYMBOL_NAME__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-EXPORT_TEST_PLUGIN(boost_plugin_loader::TestPluginMultiply, plugin)
+EXPORT_TEST_PLUGIN_MULTIPLY(boost_plugin_loader::TestPluginMultiplyImpl, __SYMBOL_NAME__)

--- a/test/test_plugin_multiply.h
+++ b/test/test_plugin_multiply.h
@@ -19,26 +19,26 @@
 #ifndef BOOST_PLUGIN_LOADER_TEST_PLUGIN_SUM_H
 #define BOOST_PLUGIN_LOADER_TEST_PLUGIN_SUM_H
 
-#include "test_plugin_base.h"
+#include "test_plugin.h"
 
 // Boost Plugin Loader
 #include <boost_plugin_loader/macros.h>
 
 namespace boost_plugin_loader
 {
-class TestPluginMultiply : public TestPluginBase
+class TestPluginMultiplyImpl : public TestPluginMultiply
 {
 public:
-  TestPluginMultiply() = default;
-  ~TestPluginMultiply() override = default;
-  TestPluginMultiply(const TestPluginMultiply&) = default;
-  TestPluginMultiply& operator=(const TestPluginMultiply&) = default;
-  TestPluginMultiply(TestPluginMultiply&&) = default;
-  TestPluginMultiply& operator=(TestPluginMultiply&&) = default;
+  TestPluginMultiplyImpl() = default;
+  ~TestPluginMultiplyImpl() override = default;
+  TestPluginMultiplyImpl(const TestPluginMultiplyImpl&) = default;
+  TestPluginMultiplyImpl& operator=(const TestPluginMultiplyImpl&) = default;
+  TestPluginMultiplyImpl(TestPluginMultiplyImpl&&) = default;
+  TestPluginMultiplyImpl& operator=(TestPluginMultiplyImpl&&) = default;
   double multiply(double x, double y) override;
 };
 
-PLUGIN_ANCHOR_DECL(TestPluginMultiplyAnchor)
+PLUGIN_ANCHOR_DECL(TestPluginMultiplyImplAnchor)
 
 }  // namespace boost_plugin_loader
 


### PR DESCRIPTION
I ran into a use-case where I have two plugin libraries with different section names that use the same symbol name(s) to denote plugins. The plugin loader currently loops over the identified plugin libraries (which are ordered arbitrarily) and only checks if the symbol exists in the library before returning the first plugin it finds, regardless of whether that symbol is belongs to the section associated with the plugin typedef. In my case, it found the incorrect library first and caused a segfault because it didn't load the correct plugin object.

The fix provided in this PR adds two functions for checking the validity of a symbol in a library (`hasSymbol`). When the plugin type has a section, this method checks that the requested symbol is in the list of symbols associated with the section. Otherwise, it just checks if the library contains that symbol (i.e., the current behavior).

Note: the added method needs to be added to the class itself because it needs access to `getSection` which is generally a private method that is accessible to the `PluginLoader` class (via the `friend class` declaration in the plugin type) but is not accessible to other functions