### PR TITLE
Bug fix so search path order is preserved

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -84,8 +84,8 @@ int main(int /*argc*/, char** /*argv*/)  // NOLINT
 {
   // Create and configure the plugin loader to be able to find libraries in which plugins exist
   PluginLoader loader;
-  loader.search_paths.insert(PLUGIN_DIR);
-  loader.search_libraries.insert(PLUGINS);
+  loader.search_paths.push_back(PLUGIN_DIR);
+  loader.search_libraries.push_back(PLUGINS);
 
   // Printer plugins
   demoPrinterPlugins(loader);

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -84,8 +84,8 @@ int main(int /*argc*/, char** /*argv*/)  // NOLINT
 {
   // Create and configure the plugin loader to be able to find libraries in which plugins exist
   PluginLoader loader;
-  loader.search_paths.push_back(PLUGIN_DIR);
-  loader.search_libraries.push_back(PLUGINS);
+  loader.search_paths.emplace_back(PLUGIN_DIR);
+  loader.search_libraries.emplace_back(PLUGINS);
 
   // Printer plugins
   demoPrinterPlugins(loader);

--- a/include/boost_plugin_loader/fwd.h
+++ b/include/boost_plugin_loader/fwd.h
@@ -22,6 +22,6 @@
 namespace boost_plugin_loader
 {
 class PluginLoader;
-}
+}  // namespace boost_plugin_loader
 
 #endif  // BOOST_PLUGIN_LOADER_FWD_H

--- a/include/boost_plugin_loader/plugin_loader.h
+++ b/include/boost_plugin_loader/plugin_loader.h
@@ -20,7 +20,6 @@
 #define BOOST_PLUGIN_LOADER_PLUGIN_LOADER_H
 
 // STD
-#include <set>
 #include <string>
 #include <memory>
 #include <vector>
@@ -37,6 +36,7 @@ class shared_library;
 
 namespace boost_plugin_loader
 {
+
 /** @brief Used to test for getSection method for getAvailablePlugins */
 template <typename T>
 struct has_getSection
@@ -79,10 +79,10 @@ public:
   bool search_system_folders{ true };
 
   /** @brief A list of paths to search for plugins */
-  std::set<std::string> search_paths;
+  std::vector<std::string> search_paths;
 
   /** @brief A list of library names without the prefix or suffix that contain plugins*/
-  std::set<std::string> search_libraries;
+  std::vector<std::string> search_libraries;
 
   /** @brief The environment variable containing plugin search paths */
   std::string search_paths_env;
@@ -149,18 +149,18 @@ public:
 protected:
   template <typename PluginBase>
   void reportErrorCommon(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-                         const std::set<std::string>& search_paths,
-                         const std::set<std::string>& search_libraries) const;
+                         const std::vector<std::string>& search_paths,
+                         const std::vector<std::string>& search_libraries) const;
 
   template <typename PluginBase>
   typename std::enable_if_t<!has_getSection<PluginBase>::value, void>
   reportError(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-              const std::set<std::string>& search_paths, const std::set<std::string>& search_libraries) const;
+              const std::vector<std::string>& search_paths, const std::vector<std::string>& search_libraries) const;
 
   template <typename PluginBase>
   typename std::enable_if_t<has_getSection<PluginBase>::value, void>
   reportError(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-              const std::set<std::string>& search_paths, const std::set<std::string>& search_libraries) const;
+              const std::vector<std::string>& search_paths, const std::vector<std::string>& search_libraries) const;
 
   /**
    * @brief Checks if the library has the input symbol name, given that the plugin class does not define a section name

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -96,8 +96,8 @@ PluginLoader::hasSymbol(const boost::dll::shared_library& lib, const std::string
  * Libraries specified with absolute paths will be returned first in the list before libraries found in local paths (but
  * in no particular order in at the front of the list).
  */
-static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std::string>& library_names,
-                                                             const std::set<std::string>& search_paths_local,
+static std::vector<boost::dll::shared_library> loadLibraries(const std::vector<std::string>& library_names,
+                                                             const std::vector<std::string>& search_paths_local,
                                                              const bool search_system_folders)
 {
   std::vector<boost::dll::shared_library> libraries;
@@ -157,8 +157,8 @@ static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std:
 
 template <typename PluginBase>
 void PluginLoader::reportErrorCommon(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-                                     const std::set<std::string>& search_paths,
-                                     const std::set<std::string>& search_libraries) const
+                                     const std::vector<std::string>& search_paths,
+                                     const std::vector<std::string>& search_libraries) const
 {
   const std::string plugin_base_type = boost::core::demangle(typeid(PluginBase).name());
   msg << "Failed to create plugin instance '" << plugin_name << "' of type '" << plugin_base_type << "'\n";
@@ -176,8 +176,8 @@ void PluginLoader::reportErrorCommon(std::ostream& msg, const std::string& plugi
 template <typename PluginBase>
 typename std::enable_if_t<!has_getSection<PluginBase>::value, void>
 PluginLoader::reportError(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-                          const std::set<std::string>& search_paths,
-                          const std::set<std::string>& search_libraries) const
+                          const std::vector<std::string>& search_paths,
+                          const std::vector<std::string>& search_libraries) const
 {
   return reportErrorCommon<PluginBase>(msg, plugin_name, search_system_folders, search_paths, search_libraries);
 }
@@ -185,8 +185,8 @@ PluginLoader::reportError(std::ostream& msg, const std::string& plugin_name, boo
 template <typename PluginBase>
 typename std::enable_if_t<has_getSection<PluginBase>::value, void>
 PluginLoader::reportError(std::ostream& msg, const std::string& plugin_name, bool search_system_folders,
-                          const std::set<std::string>& search_paths,
-                          const std::set<std::string>& search_libraries) const
+                          const std::vector<std::string>& search_paths,
+                          const std::vector<std::string>& search_libraries) const
 {
   reportErrorCommon<PluginBase>(msg, plugin_name, search_system_folders, search_paths, search_libraries);
 
@@ -202,12 +202,12 @@ template <class PluginBase>
 std::shared_ptr<PluginBase> PluginLoader::createInstance(const std::string& plugin_name) const
 {
   // Check for environment variable for plugin definitions
-  const std::set<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
+  const std::vector<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
   if (library_names.empty())
     throw PluginLoaderException("No plugin libraries were provided!");
 
   // Check for environment variable for search paths
-  const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
+  const std::vector<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
   const std::vector<boost::dll::shared_library> libraries =
@@ -228,12 +228,12 @@ std::shared_ptr<PluginBase> PluginLoader::createInstance(const std::string& plug
 bool PluginLoader::isPluginAvailable(const std::string& plugin_name) const
 {
   // Check for environment variable for plugin definitions
-  const std::set<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
+  const std::vector<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
   if (library_names.empty())
     throw PluginLoaderException("No plugin libraries were provided!");
 
   // Check for environment variable for search paths
-  const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
+  const std::vector<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
   const std::vector<boost::dll::shared_library> libraries =
@@ -253,12 +253,12 @@ PluginLoader::getAvailablePlugins() const
 std::vector<std::string> PluginLoader::getAvailablePlugins(const std::string& section) const
 {
   // Check for environment variable for plugin definitions
-  const std::set<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
+  const std::vector<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
   if (library_names.empty())
     throw PluginLoaderException("No plugin libraries were provided!");
 
   // Check for environment variable for search paths
-  const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
+  const std::vector<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
   const std::vector<boost::dll::shared_library> libraries =
@@ -278,12 +278,12 @@ std::vector<std::string> PluginLoader::getAvailablePlugins(const std::string& se
 std::vector<std::string> PluginLoader::getAvailableSections(bool include_hidden) const
 {
   // Check for environment variable for plugin definitions
-  const std::set<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
+  const std::vector<std::string> library_names = getAllLibraryNames(search_libraries_env, search_libraries);
   if (library_names.empty())
     throw PluginLoaderException("No plugin libraries were provided!");
 
   // Check for environment variable for search paths
-  const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
+  const std::vector<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
   const std::vector<boost::dll::shared_library> libraries =

--- a/include/boost_plugin_loader/utils.h
+++ b/include/boost_plugin_loader/utils.h
@@ -22,7 +22,6 @@
 // STD
 #include <string>
 #include <vector>
-#include <set>
 #include <optional>
 
 // Boost
@@ -30,6 +29,7 @@
 
 namespace boost_plugin_loader
 {
+
 /** @brief The Boost Plugin Loader Exception class */
 class PluginLoaderException : public std::runtime_error
 {
@@ -83,7 +83,7 @@ std::string decorate(const std::string& library_name, const std::string& library
  * @param env_variable The environment variable name to extract list from
  * @return A list extracted from variable name
  */
-std::set<std::string> parseEnvironmentVariableList(const std::string& env_variable);
+std::vector<std::string> parseEnvironmentVariableList(const std::string& env_variable);
 
 /**
  * @brief Get all available search paths
@@ -91,8 +91,8 @@ std::set<std::string> parseEnvironmentVariableList(const std::string& env_variab
  * @param existing_search_libraries A list of existing search paths
  * @return A list of search paths
  */
-std::set<std::string> getAllSearchPaths(const std::string& search_paths_env,
-                                        const std::set<std::string>& existing_search_paths);
+std::vector<std::string> getAllSearchPaths(const std::string& search_paths_env,
+                                           const std::vector<std::string>& existing_search_paths);
 
 /**
  * @brief Get all available library names
@@ -100,8 +100,8 @@ std::set<std::string> getAllSearchPaths(const std::string& search_paths_env,
  * @param existing_search_libraries A list of existing library names without the prefix or suffix that contain plugins
  * @return A list of library names without the prefix or suffix that contain plugins
  */
-std::set<std::string> getAllLibraryNames(const std::string& search_libraries_env,
-                                         const std::set<std::string>& existing_search_libraries);
+std::vector<std::string> getAllLibraryNames(const std::string& search_libraries_env,
+                                            const std::vector<std::string>& existing_search_libraries);
 
 /**
  * @brief Utility function to add library containing symbol to the search env variable

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,7 +32,6 @@
 // STD
 #include <vector>
 #include <string>
-#include <set>
 #include <algorithm>
 #include <optional>
 #include <cstring>
@@ -117,44 +116,47 @@ std::string decorate(const std::string& library_name, const std::string& library
   return actual_path.string();
 }
 
-std::set<std::string> parseEnvironmentVariableList(const std::string& env_variable)
+std::vector<std::string> parseEnvironmentVariableList(const std::string& env_variable)
 {
-  std::set<std::string> list;
   char* env_var = std::getenv(env_variable.c_str());
   if (env_var == nullptr)  // Environment variable not found
-    return list;
+    return {};
 
   std::string evn_str = std::string(env_var);
+  std::vector<std::string> env_list;
 #ifndef _WIN32
-  boost::split(list, evn_str, boost::is_any_of(":"), boost::token_compress_on);
+  boost::split(env_list, evn_str, boost::is_any_of(":"), boost::token_compress_on);
 #else
-  boost::split(list, evn_str, boost::is_any_of(";"), boost::token_compress_on);
+  boost::split(env_list, evn_str, boost::is_any_of(";"), boost::token_compress_on);
 #endif
+
+  std::vector<std::string> list;
+  list.insert(list.end(), env_list.begin(), env_list.end());
   return list;
 }
 
-std::set<std::string> getAllSearchPaths(const std::string& search_paths_env,
-                                        const std::set<std::string>& existing_search_paths)
+std::vector<std::string> getAllSearchPaths(const std::string& search_paths_env,
+                                           const std::vector<std::string>& existing_search_paths)
 {
   // Check for environment variable to override default library
   if (!search_paths_env.empty())
   {
-    std::set<std::string> search_paths = parseEnvironmentVariableList(search_paths_env);
-    search_paths.insert(existing_search_paths.begin(), existing_search_paths.end());
+    std::vector<std::string> search_paths = parseEnvironmentVariableList(search_paths_env);
+    search_paths.insert(search_paths.end(), existing_search_paths.begin(), existing_search_paths.end());
     return search_paths;
   }
 
   return existing_search_paths;
 }
 
-std::set<std::string> getAllLibraryNames(const std::string& search_libraries_env,
-                                         const std::set<std::string>& existing_search_libraries)
+std::vector<std::string> getAllLibraryNames(const std::string& search_libraries_env,
+                                            const std::vector<std::string>& existing_search_libraries)
 {
   // Check for environment variable to override default library
   if (!search_libraries_env.empty())
   {
-    std::set<std::string> search_libraries = parseEnvironmentVariableList(search_libraries_env);
-    search_libraries.insert(existing_search_libraries.begin(), existing_search_libraries.end());
+    std::vector<std::string> search_libraries = parseEnvironmentVariableList(search_libraries_env);
+    search_libraries.insert(search_libraries.end(), existing_search_libraries.begin(), existing_search_libraries.end());
     return search_libraries;
   }
 

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -174,8 +174,8 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
 
   {
     PluginLoader plugin_loader;
-    plugin_loader.search_paths.push_back(std::string(PLUGIN_DIR));
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_paths.emplace_back(PLUGIN_DIR);
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
 
     EXPECT_TRUE(plugin_loader.isPluginAvailable(getSymbolName()));
     auto plugin = plugin_loader.createInstance<TestPluginMultiply>(getSymbolName());
@@ -230,7 +230,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
     PluginLoader plugin_loader;
     EXPECT_EQ(plugin_loader.count(), 0);
     EXPECT_TRUE(plugin_loader.empty());
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
     EXPECT_EQ(plugin_loader.count(), 1);
     EXPECT_FALSE(plugin_loader.empty());
 
@@ -245,8 +245,8 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_paths.push_back("does_not_exist");
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_paths.emplace_back("does_not_exist");
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
 
     EXPECT_FALSE(plugin_loader.isPluginAvailable(getSymbolName()));
     // Behavior change: used to return nullptr but now throws exception
@@ -258,7 +258,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
 
     {
       EXPECT_FALSE(plugin_loader.isPluginAvailable("does_not_exist"));
@@ -280,7 +280,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_libraries.push_back("does_not_exist");
+    plugin_loader.search_libraries.emplace_back("does_not_exist");
 
     {
       EXPECT_FALSE(plugin_loader.isPluginAvailable(getSymbolName()));
@@ -302,7 +302,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = false;
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
@@ -312,7 +312,7 @@ TEST(BoostPluginLoaderUnit, LoadTestPlugin)  // NOLINT
   {
     PluginLoader plugin_loader;
     plugin_loader.search_system_folders = true;
-    plugin_loader.search_libraries.push_back(std::string(PLUGINS_MULTIPLY));
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
 
     const std::vector<std::string> plugins = plugin_loader.getAvailablePlugins(TestPluginMultiply::getSection());
     EXPECT_EQ(plugins.size(), 1);
@@ -365,8 +365,8 @@ TEST(BoostPluginLoaderUnit, LoadTestPluginsSameSymbolDifferentSections)  // NOLI
   // Try to load an instance of `TestPluginAddImpl` from the library in which `TestPluginMultiplyImpl` was defined
   {
     PluginLoader plugin_loader;
-    plugin_loader.search_libraries.push_back(PLUGINS_MULTIPLY);
-    plugin_loader.search_paths.push_back(PLUGIN_DIR);
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
+    plugin_loader.search_paths.emplace_back(PLUGIN_DIR);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginAdd>(getSymbolName()));
@@ -375,8 +375,8 @@ TEST(BoostPluginLoaderUnit, LoadTestPluginsSameSymbolDifferentSections)  // NOLI
   // Try to load an instance of `TestPluginMultiplyImpl` from the library in which `TestPluginAddImpl` was defined
   {
     PluginLoader plugin_loader;
-    plugin_loader.search_libraries.push_back(PLUGINS_ADD);
-    plugin_loader.search_paths.push_back(PLUGIN_DIR);
+    plugin_loader.search_libraries.emplace_back(PLUGINS_ADD);
+    plugin_loader.search_paths.emplace_back(PLUGIN_DIR);
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto)
     EXPECT_ANY_THROW(plugin_loader.createInstance<TestPluginMultiply>(getSymbolName()));
@@ -385,9 +385,9 @@ TEST(BoostPluginLoaderUnit, LoadTestPluginsSameSymbolDifferentSections)  // NOLI
   // Given both libraries, correctly load and use each plugin, even though they share the same symbol name
   {
     PluginLoader plugin_loader;
-    plugin_loader.search_libraries.push_back(PLUGINS_ADD);
-    plugin_loader.search_libraries.push_back(PLUGINS_MULTIPLY);
-    plugin_loader.search_paths.push_back(PLUGIN_DIR);
+    plugin_loader.search_libraries.emplace_back(PLUGINS_ADD);
+    plugin_loader.search_libraries.emplace_back(PLUGINS_MULTIPLY);
+    plugin_loader.search_paths.emplace_back(PLUGIN_DIR);
 
     // Load and use a multiply plugin
     {


### PR DESCRIPTION
When debugging PR #34 I found that std::set does not preserve order which I believe is not what we want for the search paths and library names. @marip8 do you agree?