### PR TITLE
Fixed finding multiple libraries during library loading

### DIFF
--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -154,9 +154,9 @@ loadLibraries(const std::vector<std::string>& library_names, const std::vector<s
   libraries.reserve(library_names.size());
 
   // Loop over each provided library name
-  std::optional<boost::dll::shared_library> lib = std::nullopt;
   for (const std::string& library_name : library_names)
   {
+    std::optional<boost::dll::shared_library> lib = std::nullopt;
     // First check if the library name is actually a complete, absolute path where the library is located
     {
       const boost::filesystem::path library_path(library_name);


### PR DESCRIPTION
This PR fixes a bug where if multiple library names are provided when loading libraries and system level directories are being searched, both libraries are found instead of the first one.  